### PR TITLE
chore: fix codeowners for workflows dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,9 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
+/.github/                                       @hashgraph/release-engineering @hashgraph/release-engineering-manager
 /.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
+/.github/depandabot.yml                         @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
 
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below
-*                                              @hashgraph/developer-advocates
+*                                               @hashgraph/developer-advocates
 
 #########################
 #####  Core Files  ######
@@ -11,12 +11,12 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/release-engineering @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
+/.github/                                       @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
+/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
 
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
-/CODEOWNERS                                      @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
+/CODEOWNERS                                     @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
 
 # Protect the repository root files
 /README.md                                      @hashgraph/release-engineering @hashgraph/release-engineering-managers  @hashgraph/developer-advocates

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/release-engineering @hashgraph/release-engineering-manager
+/.github/                                       @hashgraph/release-engineering @hashgraph/release-engineering-managers
 /.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
 /.github/depandabot.yml                         @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/developer-advocates
-/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
 
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)


### PR DESCRIPTION
**Description**:
Resolve the CODEOWNER file so the line reads:

`/.github/workflows/    @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers`

If there are additional owners on the `/.github` folder, that should be declared in a separate line.

**Related issue(s)**:

Fixes #107 

**Notes for reviewer**:
N/A

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
