### PR TITLE
chore: Update flow-pull-request-checks.yaml to use initialize-github-job

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -23,18 +23,15 @@ jobs:
       matrix:
         node-version: [ 18, 20 ]
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@ed4a98646fe0235e6ecf3af5414b355d2abe3bf3 # v1.0.3
         with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-        with:
-          node-version: ${{ matrix.node-version }}
+          checkout: 'true'
+          checkout-ref: '${{ github.ref }}'
+          checkout-fetch-depth: '0'
+          checkout-token: '${{ secrets.GITHUB_TOKEN }}'
+          setup-node: 'true'
+          node-version: '${{ matrix.node-version }}'
 
       - name: Install packages
         run: npm ci


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow for pull request checks by replacing the previous runner hardening and setup steps with a single composite action that handles both repository checkout and Node.js setup. This streamlines the workflow configuration and consolidates multiple steps into one.

Workflow improvements:

* Replaced the `step-security/harden-runner` and separate `actions/checkout` and `actions/setup-node` steps with the `pandaswhocode/initialize-github-job` composite action in `.github/workflows/flow-pull-request-checks.yaml`, which now performs runner preparation, repository checkout, and Node.js setup in a single step.

## Related Issues

Closes #122 